### PR TITLE
Update Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,15 +32,6 @@ The app is installed
 Before configuring the App, we strongly recommend that you create a dedicated account in OpenCTI with the same properties as for a connector user account.
 To create this account, please refer to [Connector users and Tokens](https://docs.opencti.io/latest/deployment/connectors/?h=connector+user#connector-users-and-tokens) documentation.
 
-> [!WARNING]  
-> As the application can generate many requests to OpenCTI without maintaining an HTTP session, it's strongly recommended to activate the “Use stateless mode” option on this user account.
-
-Proceed as follows to enable the "stateless mode" option:
-1. Update the previously created user and click on "Advanced options"
-2. Enable the "Use stateless mode" options
-
-![](./.github/img/config_stateless_mode.png "Stateless Mode")
-
 ### General Add-On settings
 
 1. Navigate to Splunk Web UI home page, open the "OpenCTI add-on for Splunk" and navigate to "Configuration" page.

--- a/README.md
+++ b/README.md
@@ -133,7 +133,6 @@ Example of a configuration to create an incident in OpenCTI
 
 ![](./.github/img/alert_example.png "Alert Example")
 
-
 ### Observables extraction
 
 To extract and model alert fields as OpenCTI observables attached to the incident or incident response case, the Add-on purpose two methods describe below.


### PR DESCRIPTION
Removal of the part of the documentation that specifies enabling “stateless mode” on the user account, as this option is not useful and has been removed in OpenCTI 6.6.0.