### PR TITLE
fix: seed incident IDs with Splunk rid to prevent same-second collisions (#44)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ local.meta
 
 # Splunk local folder
 local
+.DS_Store

--- a/TA-opencti-add-on/bin/ta_opencti_add_on/stix_converter.py
+++ b/TA-opencti-add-on/bin/ta_opencti_add_on/stix_converter.py
@@ -267,6 +267,7 @@ def convert_to_incident_response(alert_params, event):
     :return:
     """
     bundle_objects = []
+    rid = event.get("rid") or ""
 
     # event date
     if "_time" in event and event.get("_time"):
@@ -309,7 +310,7 @@ def convert_to_incident_response(alert_params, event):
 
     # create incident response case
     stix_case_incident = CustomObjectCaseIncident(
-        id=generate_case_incident_id(alert_params.get("name"), event_date),
+        id=generate_case_incident_id(alert_params.get("name"), event_date, rid),
         name=alert_params.get("name"),
         description=alert_params.get("description"),
         severity=alert_params.get("severity"),
@@ -334,6 +335,7 @@ def convert_to_incident(alert_params, event):
     :return:
     """
     bundle_objects = []
+    rid = event.get("rid") or ""
 
     # event date
     if "_time" in event and event.get("_time"):
@@ -376,7 +378,7 @@ def convert_to_incident(alert_params, event):
 
     # create incident
     stix_incident = stix2.Incident(
-        id=generate_incident_id(alert_params.get("name"), event_date),
+        id=generate_incident_id(alert_params.get("name"), event_date, rid),
         name=alert_params.get("name"),
         created=event_date,
         description=alert_params.get("description"),

--- a/TA-opencti-add-on/bin/ta_opencti_add_on/tests/test_incident_id_rid.py
+++ b/TA-opencti-add-on/bin/ta_opencti_add_on/tests/test_incident_id_rid.py
@@ -1,0 +1,50 @@
+import datetime
+import os
+import sys
+import unittest
+
+
+CURRENT_DIR = os.path.dirname(__file__)
+PACKAGE_DIR = os.path.abspath(os.path.join(CURRENT_DIR, ".."))
+AOB_PY3_DIR = os.path.join(PACKAGE_DIR, "aob_py3")
+if AOB_PY3_DIR not in sys.path:
+    sys.path.insert(0, AOB_PY3_DIR)
+if PACKAGE_DIR not in sys.path:
+    sys.path.insert(0, PACKAGE_DIR)
+
+from utils import generate_case_incident_id, generate_incident_id
+
+
+class IncidentRidIdTests(unittest.TestCase):
+    def setUp(self):
+        self.name = "Example Alert"
+        self.created = datetime.datetime(2026, 7, 27, 12, 30, 1, tzinfo=datetime.timezone.utc)
+
+    def test_different_rid_produces_different_ids(self):
+        for generator in (generate_incident_id, generate_case_incident_id):
+            with self.subTest(generator=generator.__name__):
+                id_one = generator(self.name, self.created, "0")
+                id_two = generator(self.name, self.created, "1")
+                self.assertNotEqual(id_one, id_two)
+
+    def test_same_inputs_are_idempotent(self):
+        for generator in (generate_incident_id, generate_case_incident_id):
+            with self.subTest(generator=generator.__name__):
+                first = generator(self.name, self.created, "42")
+                second = generator(self.name, self.created, "42")
+                self.assertEqual(first, second)
+
+    def test_missing_rid_falls_back_to_empty_string_deterministically(self):
+        event = {}
+        rid = event.get("rid") or ""
+
+        for generator in (generate_incident_id, generate_case_incident_id):
+            with self.subTest(generator=generator.__name__):
+                from_fallback = generator(self.name, self.created, rid)
+                explicit_empty = generator(self.name, self.created, "")
+                self.assertEqual(from_fallback, explicit_empty)
+                self.assertEqual(from_fallback, generator(self.name, self.created, rid))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/TA-opencti-add-on/bin/ta_opencti_add_on/utils.py
+++ b/TA-opencti-add-on/bin/ta_opencti_add_on/utils.py
@@ -84,15 +84,16 @@ def generate_identity_id(name: str, identity_class: str):
     entity_id = str(uuid.uuid5(uuid.UUID("00abedb4-aa42-466c-9c01-fed23315a9b7"), data))
     return "identity--" + entity_id
 
-def generate_incident_id(name: str, created):
+def generate_incident_id(name: str, created, rid: str):
     """
     :param name:
     :param created:
+    :param rid:
     :return:
     """
     if isinstance(created, datetime.datetime):
         created = created.isoformat()
-    data = {"name": name.lower().strip(), "created": created}
+    data = {"name": name.lower().strip(), "created": created, "rid": rid}
     data = canonicalize(data, utf8=False)
     entity_id = str(uuid.uuid5(uuid.UUID("00abedb4-aa42-466c-9c01-fed23315a9b7"), data))
     return "incident--" + entity_id
@@ -140,16 +141,17 @@ def generate_sighting_id(
     entity_id = str(uuid.uuid5(uuid.UUID("00abedb4-aa42-466c-9c01-fed23315a9b7"), data))
     return "sighting--" + entity_id
 
-def generate_case_incident_id(name: str, created):
+def generate_case_incident_id(name: str, created, rid: str):
     """
     :param name:
     :param created:
+    :param rid:
     :return:
     """
     name = name.lower().strip()
     if isinstance(created, datetime.datetime):
         created = created.isoformat()
-    data = {"name": name, "created": created}
+    data = {"name": name, "created": created, "rid": rid}
     data = canonicalize(data, utf8=False)
     entity_id = str(uuid.uuid5(uuid.UUID("00abedb4-aa42-466c-9c01-fed23315a9b7"), data))
     return "case-incident--" + entity_id


### PR DESCRIPTION
Fixes #44

## Problem

`generate_incident_id()` and `generate_case_incident_id()` in `utils.py` seed `uuid5` on only `{"name", "created"}`. `created` is derived from the Splunk event's `_time`, which commonly has second resolution — so two distinct alert results with the same alert name firing in the same second produce byte-identical STIX IDs, and OpenCTI upsert-merges them into a single incident. Distinct incidents are silently lost. The fallback path is worse: when `_time` is absent, `datetime.now()` is used, collapsing an entire batch processed in the same wall-clock second onto one ID.

## Fix

Add the Splunk per-result id (`rid`) to the `uuid5` seed in both ID functions:

```python
data = {"name": name.lower().strip(), "created": created, "rid": rid}
```

Both call sites in `stix_converter.py` (`convert_to_incident`, `convert_to_incident_response`) extract `rid` from the result payload and pass it through:

```python
rid = event.get("rid") or ""
```

### Why `rid` (and not a random salt)

As discussed in #44, a random/non-deterministic salt was explicitly rejected: the modular alert framework retries on failure, and a non-deterministic seed turns every retry into a duplicate incident. `rid` is deterministic per result — it maps to **event identity**, not execution identity — so:

- Same alert name + same second + **different results** → different IDs (bug fixed)
- Same result delivered twice (retry) → identical ID (idempotency preserved)
- `rid` absent → deterministic `""` fallback, degrading gracefully rather than crashing or becoming non-deterministic

## Notes for reviewers

- The `canonicalize()` serialization, namespace UUID, and all other ID functions (sightings, relationships, identities, observables) are untouched. Only the two incident ID functions and their two call sites change.
- **One-time forward ID discontinuity (accepted in #44):** because the seed dict now contains the `rid` key, all newly generated incident IDs differ from what the old code would have produced — including events without a `rid`. This is a one-time break; no migration/backward-compat lookup is included by design.
- No new configuration options — this is an unconditional bug fix.

## Tests

`tests/test_incident_id_rid.py` covers both generators:

- Same name + created, different `rid` → different IDs (the collision bug)
- Same name + created + `rid` called twice → identical ID (retry idempotency)
- Missing `rid` → deterministic empty-string fallback

## Related

The same flaw exists verbatim in `OpenCTI-Platform/splunk-enterprise-add-on` (`generate_incident_id` / `generate_case_incident_id` in `TA-opencti-for-splunk-enterprise/package/bin/utils.py`), tracked in that repo's issue #50. The equivalent fix should land there in the same review cycle so the two apps don't drift. This PR does not modify that repo.